### PR TITLE
pass TLS setting from env to openwhisk.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,8 @@ const colors = require('colors'),
       owProps = {
 	  apihost: wskprops.APIHOST || 'openwhisk.ng.bluemix.net',
 	  api_key: wskprops.AUTH,
-	  namespace: wskprops.NAMESPACE || '_'
+	  namespace: wskprops.NAMESPACE || '_',
+	  ignore_certs: process.env.NODE_TLS_REJECT_UNAUTHORIZED == "0"
       },
       ow = require('openwhisk')(owProps),
       options = argv.option([


### PR DESCRIPTION
This is not the best way to do this - rather there's a -i option for owen, or better yet, pull this info from wskprops (opened an issue in openwhisk repo to address this since it's not recorded there now).